### PR TITLE
Add GNU Octave compatibility layer

### DIFF
--- a/octave_compat/conncomp.m
+++ b/octave_compat/conncomp.m
@@ -1,0 +1,36 @@
+function [bins, binsizes] = conncomp(G)
+% CONNCOMP  Octave compatibility shim for MATLAB's conncomp.
+%   [bins, binsizes] = conncomp(G) finds connected components.
+  n = G.n;
+  visited = false(n, 1);
+  bins = zeros(n, 1);
+  comp = 0;
+
+  for start = 1:n
+    if visited(start)
+      continue;
+    end
+    comp = comp + 1;
+    queue = start;
+    visited(start) = true;
+    bins(start) = comp;
+    while ~isempty(queue)
+      node = queue(1);
+      queue(1) = [];
+      neighbors = find(G.adj(node, :));
+      for k = 1:length(neighbors)
+        nb = neighbors(k);
+        if ~visited(nb)
+          visited(nb) = true;
+          bins(nb) = comp;
+          queue(end+1) = nb;
+        end
+      end
+    end
+  end
+
+  binsizes = zeros(1, comp);
+  for i = 1:comp
+    binsizes(i) = sum(bins == i);
+  end
+end

--- a/octave_compat/graph.m
+++ b/octave_compat/graph.m
@@ -1,0 +1,18 @@
+function G = graph(s, t, w)
+% GRAPH  Octave compatibility shim for MATLAB's graph object.
+%   G = graph(s, t, w) creates a weighted undirected graph.
+  if nargin < 3
+    w = ones(size(s));
+  end
+  if isempty(s) && isempty(t)
+    n = 0;
+  else
+    n = round(double(max([s(:); t(:)])));
+  end
+  G.s = round(double(s(:)));
+  G.t = round(double(t(:)));
+  G.w = double(w(:));
+  G.n = n;
+  % Build adjacency matrix (symmetric, using minimum weight for duplicates)
+  G.adj = sparse(G.s, G.t, G.w, n, n) + sparse(G.t, G.s, G.w, n, n);
+end

--- a/octave_compat/minspantree.m
+++ b/octave_compat/minspantree.m
@@ -1,0 +1,65 @@
+function [Tree, pred] = minspantree(G, varargin)
+% MINSPANTREE  Octave compatibility shim for MATLAB's minspantree.
+%   [Tree, pred] = minspantree(G, 'Type','tree', 'Root',root)
+%   Uses Prim's algorithm.
+
+  p = inputParser;
+  addParameter(p, 'Type', 'tree');
+  addParameter(p, 'Root', 1);
+  addParameter(p, 'Method', 'dense');
+  parse(p, varargin{:});
+  root = p.Results.Root;
+
+  n = G.n;
+  inMST = false(n, 1);
+  key = inf(n, 1);
+  pred = zeros(1, n);
+  key(root) = 0;
+
+  for iter = 1:n
+    % Pick minimum key vertex not in MST
+    k = key;
+    k(inMST) = inf;
+    [minval, u] = min(k);
+    if minval == inf
+      % Disconnected component - for forest mode, find next unvisited
+      unvisited = find(~inMST, 1);
+      if isempty(unvisited)
+        break;
+      end
+      u = unvisited;
+      key(u) = 0;
+    end
+    inMST(u) = true;
+
+    % Update neighbors
+    neighbors = find(G.adj(u, :));
+    for k_idx = 1:length(neighbors)
+      v = neighbors(k_idx);
+      w = G.adj(u, v);
+      if ~inMST(v) && w < key(v)
+        key(v) = w;
+        pred(v) = u;
+      end
+    end
+  end
+
+  % Build tree graph from pred
+  s = [];
+  t = [];
+  w = [];
+  for i = 1:n
+    if pred(i) > 0
+      s(end+1) = pred(i);
+      t(end+1) = i;
+      w(end+1) = G.adj(pred(i), i);
+    end
+  end
+  if isempty(s)
+    Tree = graph([], [], []);
+    Tree.n = n;
+  else
+    Tree = graph(s(:), t(:), w(:));
+    Tree.n = n;
+  end
+end

--- a/octave_compat/quadprog.m
+++ b/octave_compat/quadprog.m
@@ -1,0 +1,53 @@
+function x = quadprog(H, f, Ain, bin, Aeq, beq, lb, ub, x0)
+% QUADPROG  Wrapper that handles rank-deficient equality constraints.
+%   Octave's quadprog requires full row rank Aeq. This removes redundant rows.
+
+  if nargin < 9, x0 = []; end
+  if nargin < 8, ub = []; end
+  if nargin < 7, lb = []; end
+  if nargin < 6, beq = []; end
+  if nargin < 5, Aeq = []; end
+  if nargin < 4, bin = []; end
+  if nargin < 3, Ain = []; end
+
+  if ~isempty(Aeq) && size(Aeq, 1) > 1
+    % Remove near-zero rows
+    row_norms = sqrt(sum(Aeq.^2, 2));
+    keep = row_norms > 1e-14;
+    Aeq = Aeq(keep, :);
+    beq = beq(keep);
+
+    % Use SVD to find rank and select independent rows
+    if size(Aeq, 1) > 1
+      [U, S, V] = svd(full(Aeq), 'econ');
+      s = diag(S);
+      tol = max(size(Aeq)) * eps(s(1));
+      r = sum(s > tol);
+      if r < size(Aeq, 1)
+        % Project to independent set: use first r rows of U'*Aeq
+        Aeq_new = U(:,1:r)' * Aeq;
+        beq_new = U(:,1:r)' * beq;
+        Aeq = Aeq_new;
+        beq = beq_new;
+      end
+    end
+  end
+
+  % Call the real quadprog from optim package via __octave_config_info__
+  % We need to avoid recursion - call the builtin directly
+  real_qp = @__qp__;
+
+  % Convert to __qp__ format: min 0.5*x'*H*x + f'*x
+  % subject to: Aeq*x = beq, Ain*x <= bin, lb <= x <= ub
+  n = length(f);
+  if isempty(lb), lb = -inf(n,1); end
+  if isempty(ub), ub = inf(n,1); end
+  if isempty(x0), x0 = zeros(n,1); end
+  if isempty(Ain), Ain = zeros(0,n); bin = zeros(0,1); end
+  if isempty(Aeq), Aeq = zeros(0,n); beq = zeros(0,1); end
+
+  [x, ~, info] = qp(x0, H, f, Aeq, beq, lb, ub, [], Ain, bin);
+  if info.info ~= 0
+    warning('quadprog: solver returned info=%d', info.info);
+  end
+end

--- a/octave_compat/readOBJ.m
+++ b/octave_compat/readOBJ.m
@@ -1,0 +1,81 @@
+function [V, F, UV, TF, N, NF, SI] = readOBJ(filename, varargin)
+% READOBJ  Fast OBJ reader for Octave. Replaces the slow fscanf-based version.
+  text = fileread(filename);
+  lines = strsplit(text, '\n');
+
+  verts = {};
+  faces = {};
+  uvs = {};
+  tfaces = {};
+  norms = {};
+  nfaces = {};
+
+  for i = 1:length(lines)
+    ln = strtrim(lines{i});
+    if isempty(ln) || ln(1) == '#'
+      continue;
+    end
+    tokens = strsplit(ln);
+    tag = tokens{1};
+
+    if strcmp(tag, 'v') && length(tokens) >= 4
+      verts{end+1} = [str2double(tokens{2}), str2double(tokens{3}), str2double(tokens{4})];
+    elseif strcmp(tag, 'vt') && length(tokens) >= 3
+      uvs{end+1} = [str2double(tokens{2}), str2double(tokens{3})];
+    elseif strcmp(tag, 'vn') && length(tokens) >= 4
+      norms{end+1} = [str2double(tokens{2}), str2double(tokens{3}), str2double(tokens{4})];
+    elseif strcmp(tag, 'f')
+      fv = [];
+      ft = [];
+      fn = [];
+      for j = 2:length(tokens)
+        parts = strsplit(tokens{j}, '/');
+        fv(end+1) = str2double(parts{1});
+        if length(parts) >= 2 && ~isempty(parts{2})
+          ft(end+1) = str2double(parts{2});
+        end
+        if length(parts) >= 3 && ~isempty(parts{3})
+          fn(end+1) = str2double(parts{3});
+        end
+      end
+      % Triangulate if needed
+      for j = 2:length(fv)-1
+        faces{end+1} = [fv(1), fv(j), fv(j+1)];
+        if ~isempty(ft)
+          tfaces{end+1} = [ft(1), ft(j), ft(j+1)];
+        end
+        if ~isempty(fn)
+          nfaces{end+1} = [fn(1), fn(j), fn(j+1)];
+        end
+      end
+    end
+  end
+
+  V = vertcat(verts{:});
+  if ~isempty(faces)
+    F = vertcat(faces{:});
+  else
+    F = zeros(0, 3);
+  end
+  if ~isempty(uvs)
+    UV = vertcat(uvs{:});
+  else
+    UV = zeros(0, 2);
+  end
+  if ~isempty(tfaces)
+    TF = vertcat(tfaces{:});
+  else
+    TF = zeros(0, 3);
+  end
+  if ~isempty(norms)
+    N = vertcat(norms{:});
+  else
+    N = zeros(0, 3);
+  end
+  if ~isempty(nfaces)
+    NF = vertcat(nfaces{:});
+  else
+    NF = zeros(0, 3);
+  end
+  SI = zeros(0, 2);
+end

--- a/octave_compat/shortestpath.m
+++ b/octave_compat/shortestpath.m
@@ -1,0 +1,44 @@
+function P = shortestpath(G, source, target)
+% SHORTESTPATH  Octave compatibility shim for MATLAB's shortestpath.
+%   P = shortestpath(G, source, target) finds shortest path using Dijkstra.
+  n = G.n;
+  dist = inf(n, 1);
+  prev = zeros(n, 1);
+  dist(source) = 0;
+  visited = false(n, 1);
+
+  for iter = 1:n
+    % Find unvisited node with smallest distance
+    d = dist;
+    d(visited) = inf;
+    [~, u] = min(d);
+    if dist(u) == inf
+      break;
+    end
+    if u == target
+      break;
+    end
+    visited(u) = true;
+
+    % Relax neighbors
+    neighbors = find(G.adj(u, :));
+    for k = 1:length(neighbors)
+      v = neighbors(k);
+      if ~visited(v)
+        alt = dist(u) + G.adj(u, v);
+        if alt < dist(v)
+          dist(v) = alt;
+          prev(v) = u;
+        end
+      end
+    end
+  end
+
+  % Reconstruct path
+  P = target;
+  u = target;
+  while prev(u) ~= 0
+    u = prev(u);
+    P = [u, P];
+  end
+end

--- a/octave_compat/wrapToPi.m
+++ b/octave_compat/wrapToPi.m
@@ -1,0 +1,4 @@
+function a = wrapToPi(a)
+% WRAPTOPI  Wraps angles to [-pi, pi].
+  a = mod(a + pi, 2*pi) - pi;
+end

--- a/run_octave_validation.m
+++ b/run_octave_validation.m
@@ -1,0 +1,134 @@
+% Octave validation script - runs RSP and saves numerical outputs for comparison
+% Usage: octave-cli --no-gui run_octave_validation.m
+
+clear all; close all; clear functions;
+
+% Add all paths; octave_compat must be first to override Utils/readOBJ etc.
+addpath(genpath(pwd));
+
+% Install optim package if not already installed (needed for quadprog)
+try
+  pkg load optim;
+catch
+  disp('Installing optim package (needed for quadprog)...');
+  pkg install -forge optim;
+  pkg load optim;
+end
+
+% octave_compat must be added AFTER pkg load to override quadprog etc.
+addpath('octave_compat');
+
+path_save = 'Results/';
+path_data = 'Mesh/';
+
+if ~exist(path_save, 'dir')
+  mkdir(path_save);
+end
+
+meshes = {'pig', 'B36', 'SquareMyles'};
+configs = {
+  struct('name','pig',         'ff','curvature', 'hardedge',false, 'boundary',true, 'seamless',true, 'energy','alignment'),
+  struct('name','B36',         'ff','smooth',    'hardedge',true,  'boundary',true, 'seamless',true, 'energy','distortion'),
+  struct('name','SquareMyles', 'ff','trivial',   'hardedge',false, 'boundary',true, 'seamless',true, 'energy','chebyshev')
+};
+
+for ci = 1:length(configs)
+  cfg = configs{ci};
+  clear functions;  % Clear persistent caches (sort_triangles) between meshes
+  addpath(genpath(pwd)); pkg load optim; addpath('octave_compat');
+  fprintf('\n=== Processing mesh: %s (ff=%s, energy=%s) ===\n', cfg.name, cfg.ff, cfg.energy);
+
+  mesh_name = cfg.name;
+  frame_field_type = cfg.ff;
+  ifhardedge = cfg.hardedge;
+  ifboundary = cfg.boundary;
+  ifseamless_const = cfg.seamless;
+  energy_type = cfg.energy;
+
+  % Energy weights
+  weight = struct();
+  if strcmp(energy_type, 'distortion')
+    weight.w_conf_ar = 0.5;
+  end
+  weight.w_gradv = 1e-2;
+
+  %% Load mesh
+  [X,T] = readOBJ([path_data, mesh_name, '.obj']);
+
+  % Rescale: area equals one
+  area_tot = sum(sqrt(sum(cross(X(T(:,1),:) - X(T(:,2),:), X(T(:,1),:) - X(T(:,3),:),2).^2,2)))/2;
+  X = X/sqrt(area_tot);
+
+  % Preprocess geometry
+  Src = MeshInfo(X, T);
+  dec = dec_tri(Src);
+  [param,Src,dec] = preprocess_ortho_param(Src, dec, ifboundary, ifhardedge, 40);
+
+  fprintf('  Vertices: %d, Faces: %d, Edges: %d\n', Src.nv, Src.nf, Src.ne);
+
+  %% Compute initial cross field
+  if strcmp(frame_field_type, 'curvature')
+    [omega,ang,sing,kappa,Curv] = compute_curvature_cross_field(Src, param, dec, 30, 1e-1);
+    weight.aspect_ratio = ((abs(kappa(:,1)) + 1e-5)./(abs(kappa(:,2)) + 1e-5));
+    t = exp(5);
+    weight.aspect_ratio = max(min(weight.aspect_ratio, t), 1/t);
+    weight.ang_dir = ang;
+    if strcmp(energy_type, 'alignment')
+      weight.w_ang   = 1;
+      weight.w_ratio = 1;
+    end
+  elseif strcmp(frame_field_type, 'smooth')
+    [omega,ang,sing] = compute_face_cross_field(Src, param, dec, 10);
+  elseif strcmp(frame_field_type, 'trivial')
+    sing = zeros(Src.nv,1);
+    sing(param.idx_bound) = round(2*param.K(param.idx_bound)/pi)/4;
+    om_cycle = param.Icycle*param.para_trans;
+    om_cycle = om_cycle - 2*pi*round(4*om_cycle/(2*pi))/4;
+    om_link = param.Ilink*param.para_trans;
+    om_link = om_link - 2*pi*round(4*om_link/(2*pi))/4;
+    [omega,ang,sing] = trivial_connection(Src, param, dec, ifboundary, ifhardedge, sing);
+  end
+
+  fprintf('  Singularities: %d positive, %d negative\n', sum(sing > 1/8), sum(sing < -1/8));
+
+  %% Compute cross field jumps and build reduction matrix
+  [Edge_jump,v2t,base_tri] = reduce_corner_var_2d(Src);
+  [k21,Reduction] = reduction_from_ff2d(Src, param, ang, omega, Edge_jump, v2t);
+
+  %% Optimize
+  itmax = 200;
+  ifplot = false;
+  u = zeros(Src.nv,1);
+  v = zeros(Src.nv,1);
+  [u,v,ut,vt,om,angn,flag] = optimize_RSP(omega, ang, u, v, Src, param, dec, Reduction, energy_type, weight, ifplot, itmax);
+
+  fprintf('  Optimization converged: %d\n', flag);
+
+  %% Compute parametrization
+  [SrcCut,dec_cut,Align,Rot] = mesh_to_disk_seamless(Src, param, angn, sing, k21, ifseamless_const, ifboundary, ifhardedge);
+  [Xp,dX] = parametrization_from_scales(Src, SrcCut, dec_cut, param, angn, om, ut, vt, Align, Rot);
+
+  %% Extract metrics
+  disto = extract_scale_from_param(Xp, Src.X, Src.T, param, SrcCut.T, angn);
+  curl_dX = sqrt(sum((dec_cut.d1p*dX).^2,2))./Src.area;
+
+  num_flipped = sum(disto.detJ <= 0);
+  fprintf('  Flipped triangles: %d / %d (%.1f%%)\n', num_flipped, Src.nf, 100*num_flipped/Src.nf);
+  fprintf('  Mean log area distortion: %.6f\n', mean(log10(disto.area)));
+  fprintf('  Mean abs log conformal: %.6f\n', mean(abs(log10(disto.conf))));
+  fprintf('  Mean curl: %.6e\n', mean(curl_dX));
+  fprintf('  UV range: [%.6f, %.6f] x [%.6f, %.6f]\n', min(Xp(:,1)), max(Xp(:,1)), min(Xp(:,2)), max(Xp(:,2)));
+
+  %% Save numerical data
+  out_prefix = [path_save, mesh_name, '_octave_'];
+  save([out_prefix, 'Xp.txt'], 'Xp', '-ascii', '-double');
+  save([out_prefix, 'ang.txt'], 'ang', '-ascii', '-double');
+  save([out_prefix, 'sing.txt'], 'sing', '-ascii', '-double');
+  save([out_prefix, 'u.txt'], 'u', '-ascii', '-double');
+  save([out_prefix, 'v.txt'], 'v', '-ascii', '-double');
+  save([out_prefix, 'omega.txt'], 'omega', '-ascii', '-double');
+
+  fprintf('  Saved numerical outputs to %s*\n', out_prefix);
+end
+
+fprintf('\n=== All meshes processed successfully ===\n');

--- a/test_B36_hardedge.m
+++ b/test_B36_hardedge.m
@@ -1,0 +1,22 @@
+clear all; close all; clear functions;
+addpath(genpath(pwd));
+pkg load optim;
+addpath('octave_compat');
+
+mesh_name = 'B36';
+fprintf('Loading %s...\n', mesh_name);
+[X,T] = readOBJ(['Mesh/', mesh_name, '.obj']);
+area_tot = sum(sqrt(sum(cross(X(T(:,1),:) - X(T(:,2),:), X(T(:,1),:) - X(T(:,3),:),2).^2,2)))/2;
+X = X/sqrt(area_tot);
+Src = MeshInfo(X, T);
+dec = dec_tri(Src);
+
+fprintf('Running preprocess with hardedge=true...\n');
+try
+  [param,Src,dec] = preprocess_ortho_param(Src, dec, true, true, 40);
+  fprintf('SUCCESS: nv=%d, nf=%d, ne=%d\n', Src.nv, Src.nf, Src.ne);
+catch e
+  fprintf('ERROR: %s\n', e.message);
+  % Debug: find which vertex causes the issue
+  fprintf('Debugging sort_triangles for boundary vertices...\n');
+end

--- a/test_octave_B36.m
+++ b/test_octave_B36.m
@@ -1,0 +1,62 @@
+% Full B36 test matching README config
+clear all; close all;
+addpath(genpath(pwd));
+pkg load optim;
+addpath('octave_compat');
+
+mesh_name = 'B36';
+frame_field_type = 'smooth';
+ifhardedge = false;
+ifboundary = true;
+ifseamless_const = true;
+energy_type = 'distortion';
+weight.w_conf_ar = 0.5;
+weight.w_gradv = 1e-2;
+
+fprintf('Loading %s...\n', mesh_name);
+[X,T] = readOBJ(['Mesh/', mesh_name, '.obj']);
+area_tot = sum(sqrt(sum(cross(X(T(:,1),:) - X(T(:,2),:), X(T(:,1),:) - X(T(:,3),:),2).^2,2)))/2;
+X = X/sqrt(area_tot);
+Src = MeshInfo(X, T);
+dec = dec_tri(Src);
+fprintf('  nv=%d, nf=%d, ne=%d\n', Src.nv, Src.nf, Src.ne);
+
+fprintf('Preprocessing...\n');
+[param,Src,dec] = preprocess_ortho_param(Src, dec, ifboundary, ifhardedge, 40);
+fprintf('  ide_fix=%d, ide_hard=%d\n', length(param.ide_fix), length(param.ide_hard));
+
+fprintf('Cross field...\n');
+[omega,ang,sing] = compute_face_cross_field(Src, param, dec, 10);
+fprintf('  Singularities: %d pos, %d neg\n', sum(sing > 1/8), sum(sing < -1/8));
+
+fprintf('Reduction...\n');
+[Edge_jump,v2t,base_tri] = reduce_corner_var_2d(Src);
+[k21,Reduction] = reduction_from_ff2d(Src, param, ang, omega, Edge_jump, v2t);
+
+fprintf('Optimizing...\n');
+u = zeros(Src.nv,1);
+v = zeros(Src.nv,1);
+[u,v,ut,vt,om,angn,flag] = optimize_RSP(omega, ang, u, v, Src, param, dec, Reduction, energy_type, weight, false, 200);
+fprintf('  Converged: %d\n', flag);
+
+fprintf('Computing parametrization...\n');
+[SrcCut,dec_cut,Align,Rot] = mesh_to_disk_seamless(Src, param, angn, sing, k21, ifseamless_const, ifboundary, ifhardedge);
+[Xp,dX] = parametrization_from_scales(Src, SrcCut, dec_cut, param, angn, om, ut, vt, Align, Rot);
+
+fprintf('Extracting metrics...\n');
+disto = extract_scale_from_param(Xp, Src.X, Src.T, param, SrcCut.T, angn);
+curl_dX = sqrt(sum((dec_cut.d1p*dX).^2,2))./Src.area;
+
+num_flipped = sum(disto.detJ <= 0);
+fprintf('  Flipped: %d / %d (%.1f%%)\n', num_flipped, Src.nf, 100*num_flipped/Src.nf);
+fprintf('  UV range: [%.6f, %.6f] x [%.6f, %.6f]\n', min(Xp(:,1)), max(Xp(:,1)), min(Xp(:,2)), max(Xp(:,2)));
+
+% Save outputs
+save('Results/B36_octave_Xp.txt', 'Xp', '-ascii', '-double');
+save('Results/B36_octave_ang.txt', 'ang', '-ascii', '-double');
+save('Results/B36_octave_sing.txt', 'sing', '-ascii', '-double');
+save('Results/B36_octave_u.txt', 'u', '-ascii', '-double');
+save('Results/B36_octave_v.txt', 'v', '-ascii', '-double');
+save('Results/B36_octave_omega.txt', 'omega', '-ascii', '-double');
+fprintf('Saved outputs to Results/B36_octave_*\n');
+fprintf('DONE\n');

--- a/test_octave_SquareMyles.m
+++ b/test_octave_SquareMyles.m
@@ -1,0 +1,61 @@
+% SquareMyles test - trivial connection (deterministic cross field)
+clear all; close all;
+addpath(genpath(pwd));
+pkg load optim;
+addpath('octave_compat');
+
+mesh_name = 'SquareMyles';
+frame_field_type = 'trivial';
+ifhardedge = false;
+ifboundary = true;
+ifseamless_const = true;
+energy_type = 'chebyshev';
+weight.w_gradv = 1e-2;
+
+fprintf('Loading %s...\n', mesh_name);
+[X,T] = readOBJ(['Mesh/', mesh_name, '.obj']);
+area_tot = sum(sqrt(sum(cross(X(T(:,1),:) - X(T(:,2),:), X(T(:,1),:) - X(T(:,3),:),2).^2,2)))/2;
+X = X/sqrt(area_tot);
+Src = MeshInfo(X, T);
+dec = dec_tri(Src);
+fprintf('  nv=%d, nf=%d, ne=%d\n', Src.nv, Src.nf, Src.ne);
+
+fprintf('Preprocessing...\n');
+[param,Src,dec] = preprocess_ortho_param(Src, dec, ifboundary, ifhardedge, 40);
+
+fprintf('Trivial connection...\n');
+sing = zeros(Src.nv,1);
+sing(param.idx_bound) = round(2*param.K(param.idx_bound)/pi)/4;
+om_cycle = param.Icycle*param.para_trans;
+om_cycle = om_cycle - 2*pi*round(4*om_cycle/(2*pi))/4;
+om_link = param.Ilink*param.para_trans;
+om_link = om_link - 2*pi*round(4*om_link/(2*pi))/4;
+[omega,ang,sing] = trivial_connection(Src, param, dec, ifboundary, ifhardedge, sing);
+fprintf('  Singularities: %d pos, %d neg\n', sum(sing > 1/8), sum(sing < -1/8));
+
+fprintf('Reduction...\n');
+[Edge_jump,v2t,base_tri] = reduce_corner_var_2d(Src);
+[k21,Reduction] = reduction_from_ff2d(Src, param, ang, omega, Edge_jump, v2t);
+
+fprintf('Optimizing...\n');
+u = zeros(Src.nv,1);
+v = zeros(Src.nv,1);
+[u,v,ut,vt,om,angn,flag] = optimize_RSP(omega, ang, u, v, Src, param, dec, Reduction, energy_type, weight, false, 200);
+fprintf('  Converged: %d\n', flag);
+
+fprintf('Computing parametrization...\n');
+[SrcCut,dec_cut,Align,Rot] = mesh_to_disk_seamless(Src, param, angn, sing, k21, ifseamless_const, ifboundary, ifhardedge);
+[Xp,dX] = parametrization_from_scales(Src, SrcCut, dec_cut, param, angn, om, ut, vt, Align, Rot);
+
+disto = extract_scale_from_param(Xp, Src.X, Src.T, param, SrcCut.T, angn);
+num_flipped = sum(disto.detJ <= 0);
+fprintf('  Flipped: %d / %d (%.1f%%)\n', num_flipped, Src.nf, 100*num_flipped/Src.nf);
+fprintf('  UV range: [%.6f, %.6f] x [%.6f, %.6f]\n', min(Xp(:,1)), max(Xp(:,1)), min(Xp(:,2)), max(Xp(:,2)));
+
+save('Results/SquareMyles_octave_Xp.txt', 'Xp', '-ascii', '-double');
+save('Results/SquareMyles_octave_ang.txt', 'ang', '-ascii', '-double');
+save('Results/SquareMyles_octave_sing.txt', 'sing', '-ascii', '-double');
+save('Results/SquareMyles_octave_u.txt', 'u', '-ascii', '-double');
+save('Results/SquareMyles_octave_v.txt', 'v', '-ascii', '-double');
+save('Results/SquareMyles_octave_omega.txt', 'omega', '-ascii', '-double');
+fprintf('DONE\n');

--- a/test_octave_pig.m
+++ b/test_octave_pig.m
@@ -1,0 +1,48 @@
+clear all; close all;
+addpath(genpath(pwd));
+pkg load optim;
+addpath('octave_compat');
+
+mesh_name = 'pig';
+fprintf('Loading %s...\n', mesh_name);
+[X,T] = readOBJ(['Mesh/', mesh_name, '.obj']);
+area_tot = sum(sqrt(sum(cross(X(T(:,1),:) - X(T(:,2),:), X(T(:,1),:) - X(T(:,3),:),2).^2,2)))/2;
+X = X/sqrt(area_tot);
+Src = MeshInfo(X, T);
+dec = dec_tri(Src);
+fprintf('  nv=%d, nf=%d, ne=%d\n', Src.nv, Src.nf, Src.ne);
+
+fprintf('Preprocessing...\n');
+[param,Src,dec] = preprocess_ortho_param(Src, dec, true, false, 40);
+
+fprintf('Smooth cross field...\n');
+[omega,ang,sing] = compute_face_cross_field(Src, param, dec, 10);
+fprintf('  Singularities: %d pos, %d neg\n', sum(sing > 1/8), sum(sing < -1/8));
+
+fprintf('Reduction...\n');
+[Edge_jump,v2t,base_tri] = reduce_corner_var_2d(Src);
+[k21,Reduction] = reduction_from_ff2d(Src, param, ang, omega, Edge_jump, v2t);
+
+fprintf('Optimizing (distortion, w_conf_ar=0.5)...\n');
+weight.w_conf_ar = 0.5;
+weight.w_gradv = 1e-2;
+u = zeros(Src.nv,1);
+v = zeros(Src.nv,1);
+[u,v,ut,vt,om,angn,flag] = optimize_RSP(omega, ang, u, v, Src, param, dec, Reduction, 'distortion', weight, false, 200);
+
+fprintf('Computing parametrization...\n');
+[SrcCut,dec_cut,Align,Rot] = mesh_to_disk_seamless(Src, param, angn, sing, k21, true, true, false);
+[Xp,dX] = parametrization_from_scales(Src, SrcCut, dec_cut, param, angn, om, ut, vt, Align, Rot);
+
+disto = extract_scale_from_param(Xp, Src.X, Src.T, param, SrcCut.T, angn);
+num_flipped = sum(disto.detJ <= 0);
+fprintf('  Flipped: %d / %d (%.1f%%)\n', num_flipped, Src.nf, 100*num_flipped/Src.nf);
+fprintf('  UV range: [%.6f, %.6f] x [%.6f, %.6f]\n', min(Xp(:,1)), max(Xp(:,1)), min(Xp(:,2)), max(Xp(:,2)));
+
+save('Results/pig_octave_Xp.txt', 'Xp', '-ascii', '-double');
+save('Results/pig_octave_ang.txt', 'ang', '-ascii', '-double');
+save('Results/pig_octave_sing.txt', 'sing', '-ascii', '-double');
+save('Results/pig_octave_u.txt', 'u', '-ascii', '-double');
+save('Results/pig_octave_v.txt', 'v', '-ascii', '-double');
+save('Results/pig_octave_omega.txt', 'omega', '-ascii', '-double');
+fprintf('DONE\n');

--- a/test_octave_step1.m
+++ b/test_octave_step1.m
@@ -1,0 +1,32 @@
+% Minimal Octave test - step by step
+clear all; close all;
+addpath(genpath(pwd));
+addpath('octave_compat');
+pkg load optim;
+
+fprintf('Step 1: Loading mesh...\n');
+[X,T] = readOBJ('Mesh/B36.obj');
+fprintf('  Loaded: %d vertices, %d faces\n', size(X,1), size(T,1));
+
+fprintf('Step 2: Rescaling...\n');
+area_tot = sum(sqrt(sum(cross(X(T(:,1),:) - X(T(:,2),:), X(T(:,1),:) - X(T(:,3),:),2).^2,2)))/2;
+X = X/sqrt(area_tot);
+fprintf('  Area: %.6f\n', area_tot);
+
+fprintf('Step 3: MeshInfo...\n');
+Src = MeshInfo(X, T);
+fprintf('  nv=%d, nf=%d, ne=%d\n', Src.nv, Src.nf, Src.ne);
+
+fprintf('Step 4: dec_tri...\n');
+dec = dec_tri(Src);
+fprintf('  Done\n');
+
+fprintf('Step 5: preprocess_ortho_param...\n');
+[param,Src,dec] = preprocess_ortho_param(Src, dec, true, false, 40);
+fprintf('  Done. ide_fix=%d\n', length(param.ide_fix));
+
+fprintf('Step 6: compute_face_cross_field (smooth)...\n');
+[omega,ang,sing] = compute_face_cross_field(Src, param, dec, 10);
+fprintf('  Done. Singularities: %d pos, %d neg\n', sum(sing > 1/8), sum(sing < -1/8));
+
+fprintf('All steps passed!\n');


### PR DESCRIPTION
## Summary

Adds shims and scripts so the full pipeline runs under GNU Octave (tested with 10.3.0), no MATLAB license required.

**`octave_compat/`** — drop-in replacements for MATLAB-only functions:
- `graph`, `conncomp`, `shortestpath`, `minspantree` (BFS, Dijkstra, Prim implementations)
- `quadprog` wrapper handling Octave's stricter rank requirements
- `wrapToPi`, `readOBJ` (fast bulk OBJ parser)

**Validation scripts:**
- `run_octave_validation.m` — runs all 3 benchmark meshes (pig, B36, SquareMyles) with reference configs
- `test_octave_*.m` — individual test scripts for each mesh

All three benchmark meshes produce 0 flipped triangles and converge successfully.

## Note

While porting this codebase to Python (validating against Octave), I noticed a few edge cases where `ismember` can return 0 (not found) and the result is used for array indexing — this would error on certain mesh topologies where not all expected elements are found in `tri_fix_cut`. The three benchmark meshes aren't affected. Happy to provide details or a separate PR if useful.